### PR TITLE
fix: Incorrect names in mock logger, style consistency

### DIFF
--- a/pkg/log/mocklogger/mocklogger.go
+++ b/pkg/log/mocklogger/mocklogger.go
@@ -65,12 +65,12 @@ func (t *MockLogger) Errorf(msg string, args ...interface{}) {
 	t.ErrorLogContents += fmt.Sprintln(fmt.Sprintf(msg, args...))
 }
 
-// Provider is a mock test provider that can be used for testing.
+// Provider is a mock logger provider that can be used for testing.
 type Provider struct {
-	TestLogger MockLogger
+	MockLogger *MockLogger
 }
 
-// GetLogger returns the underlying test logger.
+// GetLogger returns the underlying mock logger.
 func (p *Provider) GetLogger(string) log.Logger {
-	return &p.TestLogger
+	return p.MockLogger
 }

--- a/pkg/storage/couchdb/couchdbstore_test.go
+++ b/pkg/storage/couchdb/couchdbstore_test.go
@@ -38,7 +38,7 @@ const (
 	testDBPrefix               = "dbprefix"
 )
 
-var mockLoggerProvider = &mocklogger.Provider{} //nolint: gochecknoglobals
+var mockLoggerProvider = mocklogger.Provider{MockLogger: &mocklogger.MockLogger{}} //nolint: gochecknoglobals
 var errFailingMarshal = errors.New("failingMarshal always fails")
 var errFailingReadAll = errors.New("failingReadAll always fails")
 var errFailingUnquote = errors.New("failingUnquote always fails")
@@ -56,7 +56,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	log.Initialize(mockLoggerProvider)
+	log.Initialize(&mockLoggerProvider)
 
 	log.SetLevel(logModuleName, log.DEBUG)
 
@@ -260,7 +260,7 @@ func TestCouchDBStore_GetAll(t *testing.T) {
 		require.Equal(t, allValues[testDocKey2], []byte(testJSONValue2))
 		require.Len(t, allValues, 2)
 
-		require.Contains(t, mockLoggerProvider.TestLogger.AllLogContents,
+		require.Contains(t, mockLoggerProvider.MockLogger.AllLogContents,
 			fmt.Sprintf(designDocumentFilteredOutLogMsg, "_design/TestDesignDoc"))
 	})
 	t.Run("Success, but no key-value pairs exist", func(t *testing.T) {


### PR DESCRIPTION
- Fixed incorrect variable name and names in comments.
- Made the mock logger in the provider struct a pointer for style consistency purposes.
- Switched the mock logger provider in the CouchDB store unit tests back to a pointer for style consistency purposes.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>