### PR TITLE
feat: #79 parse HTTP sig header

### DIFF
--- a/pkg/httpsig/canonicalize.go
+++ b/pkg/httpsig/canonicalize.go
@@ -1,0 +1,57 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpsig
+
+import (
+	"fmt"
+	"net/http"
+	"net/textproto"
+	"strconv"
+	"strings"
+)
+
+// use these canonicalizers only if they are referenced in the `headers` signature header param.
+func nonHTTPHeaderContentIdentifierCanonicalizers() map[string]func(*SignatureHeaderParams, *http.Request) string {
+	return map[string]func(*SignatureHeaderParams, *http.Request) string{
+		"(created)": func(s *SignatureHeaderParams, _ *http.Request) string {
+			return strconv.FormatInt(s.Created.Unix(), 10)
+		},
+		"(expires)": func(s *SignatureHeaderParams, _ *http.Request) string {
+			return strconv.FormatInt(s.Expires.Unix(), 10)
+		},
+		"(request-target)": func(_ *SignatureHeaderParams, r *http.Request) string {
+			return strings.ToLower(r.Method) + " " + strings.ToLower(r.URL.Path)
+		},
+	}
+}
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-00#section-2.1.
+func canonicalizeHTTPHeaderValue(header string, r *http.Request) (string, error) {
+	// Section 3.2.2: If Covered Content contains an identifier for a header field that is
+	// not present or malformed in the message, the implementation MUST
+	// produce an error.
+	if _, found := r.Header[textproto.CanonicalMIMEHeaderKey(header)]; !found {
+		return "", fmt.Errorf(
+			"covered content contains an identifier for a header field that is not present: %s", header)
+	}
+
+	// 1. Create an ordered list of the field values of each instance of the header field in the message,
+	//    in the order that they occur (or will occur) in the message.
+	// As per https://tools.ietf.org/html/rfc2616#section-4.2, golang retains the order of a header's values:
+	// https://golang.org/src/net/textproto/reader.go?s=12794:12847#L474.
+	values := r.Header.Values(header)
+
+	// 2. Strip leading and trailing whitespace from each item in the list.
+	for i := range values {
+		value := values[i]
+		values[i] = strings.TrimSpace(value)
+	}
+
+	// 3.Concatenate the list items together, with a comma "","" and space "" "" between each item.
+	//   The resulting string is the canonicalized value.
+	return strings.Join(values, ", "), nil
+}

--- a/pkg/httpsig/parse.go
+++ b/pkg/httpsig/parse.go
@@ -1,0 +1,173 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpsig
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// SignatureHeaderParams holds parameters of the signature header:
+// https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-00#section-4.1.
+type SignatureHeaderParams struct {
+	Algorithm string
+	Created   *time.Time
+	Expires   *time.Time
+	KeyID     string
+	Signature string
+	Headers   []string
+}
+
+// ParseSignatureHeader will parse the value of the `Signature` HTTP header as per
+// https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-00#section-4.
+func ParseSignatureHeader(sigHeaderVal string) (*SignatureHeaderParams, error) {
+	pairs := strings.Split(sigHeaderVal, ",")
+	kv := make(map[string]string)
+
+	for i := range pairs {
+		header, value, err := format(pairs[i])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse a signature parameter: %w", err)
+		}
+
+		kv[header] = value
+	}
+
+	return params(kv)
+}
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-00#section-4
+// ABNF: sig-param = token BWS "=" BWS ( token / quoted-string ).
+func format(sigParam string) (string, string, error) {
+	const numParts = 2
+
+	kv := strings.Split(sigParam, "=")
+	if len(kv) != numParts {
+		return "", "", fmt.Errorf("invalid sigParam format: %s", sigParam)
+	}
+
+	param := strings.TrimSpace(kv[0])
+	value := strings.TrimSpace(kv[1])
+
+	return param, value, nil
+}
+
+func params(kv map[string]string) (*SignatureHeaderParams, error) {
+	p := &SignatureHeaderParams{}
+
+	for k, v := range kv {
+		parse, valid := signatureHeaderParamParser()[k]
+		if !valid {
+			return nil, fmt.Errorf("unrecognized signature parameter: [%s=%s]", k, v)
+		}
+
+		err := parse(p, v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse value [%s] for k [%s]: %w", v, k, err)
+		}
+	}
+
+	setDefaultValues(p)
+
+	return p, ensureRequiredParams(p)
+}
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-00#section-4.1
+func ensureRequiredParams(s *SignatureHeaderParams) error {
+	if s.KeyID == "" {
+		return fmt.Errorf("keyId is required")
+	}
+
+	if s.Signature == "" {
+		return fmt.Errorf("signature is required")
+	}
+
+	return nil
+}
+
+// Default values as per https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-00#section-4.1.
+func setDefaultValues(s *SignatureHeaderParams) {
+	if len(s.Headers) == 0 {
+		s.Headers = []string{"(created)"}
+	}
+
+	if s.Algorithm == "" {
+		s.Algorithm = "hs2019"
+	}
+}
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-00#section-3.1
+func signatureHeaderParamParser() map[string]func(*SignatureHeaderParams, string) error {
+	return map[string]func(*SignatureHeaderParams, string) error{
+		"algorithm": func(s *SignatureHeaderParams, v string) error {
+			var err error
+
+			s.Algorithm, err = parseQuotedString(v)
+
+			return err
+		},
+		"keyId": func(s *SignatureHeaderParams, v string) error {
+			var err error
+
+			s.KeyID, err = parseQuotedString(v)
+
+			return err
+		},
+		"signature": func(s *SignatureHeaderParams, v string) error {
+			var err error
+
+			s.Signature, err = parseQuotedString(v)
+
+			return err
+		},
+		"created": func(s *SignatureHeaderParams, v string) error {
+			var err error
+
+			s.Created, err = parseUnixTime(v)
+
+			return err
+		},
+		"expires": func(s *SignatureHeaderParams, v string) error {
+			var err error
+
+			s.Expires, err = parseUnixTime(v)
+
+			return err
+		},
+		"headers": func(s *SignatureHeaderParams, v string) error {
+			coveredContent, err := parseQuotedString(v)
+			if err != nil {
+				return fmt.Errorf("failed to parse covered content: %w", err)
+			}
+
+			s.Headers = strings.Split(coveredContent, " ")
+
+			return nil
+		},
+	}
+}
+
+func parseQuotedString(v string) (string, error) {
+	if !strings.HasPrefix(v, `"`) || !strings.HasSuffix(v, `"`) {
+		return "", fmt.Errorf("invalid quoted-string format: %s", v)
+	}
+
+	return strings.TrimSuffix(strings.TrimPrefix(v, `"`), `"`), nil
+}
+
+func parseUnixTime(v string) (*time.Time, error) {
+	i, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	t := time.Unix(i, 0)
+
+	return &t, nil
+}

--- a/pkg/httpsig/parse_test.go
+++ b/pkg/httpsig/parse_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpsig_test
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/edge-core/pkg/httpsig"
+)
+
+func TestParseSignatureHeader(t *testing.T) {
+	t.Run("5.2.2 parses initial contents", func(t *testing.T) {
+		result, err := httpsig.ParseSignatureHeader(`keyId="test-key-b", algorithm="rsa-sha256", ` +
+			`created=1402170695, expires=1402170995, ` +
+			`headers="(request-target) (created) host date cache-control x-emptyheader x-example", ` +
+			`signature="T1l3tWH2cSP31nfuvc3nVaHQ6IAu9YLEXg2pCeEOJETXnlWbgKtBTa"`)
+		require.NoError(t, err)
+		require.Equal(t, "test-key-b", result.KeyID)
+		require.Equal(t, "rsa-sha256", result.Algorithm)
+		require.Equal(t, unixTime(t, "1402170695"), result.Created)
+		require.Equal(t, unixTime(t, "1402170995"), result.Expires)
+		for _, h := range strings.Split("host date cache-control x-emptyheader x-example", " ") {
+			require.Contains(t, result.Headers, h)
+		}
+		require.Equal(t, "T1l3tWH2cSP31nfuvc3nVaHQ6IAu9YLEXg2pCeEOJETXnlWbgKtBTa", result.Signature)
+	})
+
+	t.Run("fails on non-defined parameters", func(t *testing.T) {
+		_, err := httpsig.ParseSignatureHeader(`invalid="some_value"`)
+		require.Error(t, err)
+	})
+
+	t.Run("4. fails on incorrect parameter format", func(t *testing.T) {
+		_, err := httpsig.ParseSignatureHeader(`created=123=456`)
+		require.Error(t, err)
+	})
+
+	t.Run("2.2 (created) must be an integer string", func(t *testing.T) {
+		_, err := httpsig.ParseSignatureHeader(`created=abc`)
+		require.Error(t, err)
+		_, err = httpsig.ParseSignatureHeader(`created="123"`)
+		require.Error(t, err)
+	})
+
+	t.Run("2.3 (expires) must be an integer string", func(t *testing.T) {
+		_, err := httpsig.ParseSignatureHeader(`expires=abc`)
+		require.Error(t, err)
+		_, err = httpsig.ParseSignatureHeader(`expires="123"`)
+		require.Error(t, err)
+	})
+
+	t.Run("4.1 headers must be a quoted string", func(t *testing.T) {
+		_, err := httpsig.ParseSignatureHeader(`headers=test`)
+		require.Error(t, err)
+	})
+
+	t.Run("4.1 default value for 'headers' is '(created)'", func(t *testing.T) {
+		result, err := httpsig.ParseSignatureHeader(`keyId="key-abc", signature="123l;kajsdlfkj"`)
+		require.NoError(t, err)
+		require.Len(t, result.Headers, 1)
+		require.Contains(t, result.Headers, "(created)")
+	})
+
+	t.Run("4.1 keyId is REQUIRED", func(t *testing.T) {
+		_, err := httpsig.ParseSignatureHeader(`signature="abc"`)
+		require.Error(t, err)
+	})
+
+	t.Run("4.1 signature is REQUIRED", func(t *testing.T) {
+		_, err := httpsig.ParseSignatureHeader(`keyId="abc"`)
+		require.Error(t, err)
+	})
+
+	t.Run("4.1 default value for 'algorithm' is 'hs2019'", func(t *testing.T) {
+		result, err := httpsig.ParseSignatureHeader(`keyId="key-abc", signature="123l;kajsdlfkj"`)
+		require.NoError(t, err)
+		require.Equal(t, "hs2019", result.Algorithm)
+	})
+}
+
+func unixTime(t *testing.T, val string) *time.Time {
+	t.Helper()
+
+	i, err := strconv.ParseInt(val, 10, 64)
+	require.NoError(t, err)
+
+	tm := time.Unix(i, 0)
+
+	return &tm
+}

--- a/pkg/httpsig/verify.go
+++ b/pkg/httpsig/verify.go
@@ -1,0 +1,108 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpsig
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// CreateSignatureInput as per https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-00#section-3.2.2.
+func CreateSignatureInput(params *SignatureHeaderParams, r *http.Request) (string, error) {
+	err := ensureConsistentSignatureInput(params)
+	if err != nil {
+		return "", fmt.Errorf("invalid signature header params: %w", err)
+	}
+
+	var input []string
+
+	coveredContent := params.Headers
+
+	for i := range coveredContent {
+		var (
+			canonicalValue string
+			err            error
+		)
+
+		contentIdentifier := coveredContent[i]
+
+		canonicalizeNonHTTPHeader, nonHTTP := nonHTTPHeaderContentIdentifierCanonicalizers()[contentIdentifier]
+		switch nonHTTP {
+		case true:
+			canonicalValue = canonicalizeNonHTTPHeader(params, r)
+		default:
+			canonicalValue, err = canonicalizeHTTPHeaderValue(contentIdentifier, r)
+			if err != nil {
+				return "", fmt.Errorf("failed to canonicalize http header %s: %w", contentIdentifier, err)
+			}
+		}
+
+		// An identifier's entry is a US-ASCII string consisting of the
+		// lowercased identifier followed with a colon "":"", a space "" "", and
+		// the identifier's canonicalized value
+		entry := fmt.Sprintf("%s: %s", strings.ToLower(contentIdentifier), canonicalValue)
+		input = append(input, entry)
+	}
+
+	// the signer concatenates together
+	// entries for each identifier in the signature's Covered Content in the
+	// order it occurs in the list, with each entry separated by a newline
+	// ""\n"".
+	return strings.Join(input, "\n"), nil
+}
+
+// Section 3.2.2: If Covered Content contains "(created)" and the signature's Creation
+// Time is undefined or covered content contains "(expires)" and the signature  does not have an Expiration Time
+//  or the signature's Algorithm name starts with "rsa", "hmac", or "ecdsa" an implementation MUST produce an error.
+//
+// Validation of the presence of a referenced HTTP header is delegated to `canonicalizeHTTPHeaderValue`.
+func ensureConsistentSignatureInput(p *SignatureHeaderParams) error {
+	validators := map[string]func(*SignatureHeaderParams) error{
+		"(created)": func(p *SignatureHeaderParams) error {
+			if p.Created == nil {
+				return fmt.Errorf("undefined content for (created)")
+			}
+
+			return nil
+		},
+		"(expires)": func(p *SignatureHeaderParams) error {
+			if p.Expires == nil {
+				return fmt.Errorf("undefined ontent for (expires)")
+			}
+
+			return nil
+		},
+	}
+
+	for header, validate := range validators {
+		if stringsContain(p.Headers, header) {
+			err := validate(p)
+			if err != nil {
+				return err
+			}
+
+			switch {
+			case strings.HasPrefix(p.Algorithm, "rsa"), strings.HasPrefix(p.Algorithm, "hmac"),
+				strings.HasPrefix(p.Algorithm, "ecdsa"):
+				return fmt.Errorf("invalid algorithm %s for content identifier %s", p.Algorithm, header)
+			}
+		}
+	}
+
+	return nil
+}
+
+func stringsContain(strs []string, v string) bool {
+	for i := range strs {
+		if v == strs[i] {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/httpsig/verify_test.go
+++ b/pkg/httpsig/verify_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpsig_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/edge-core/pkg/httpsig"
+)
+
+func TestCreateSignatureInput(t *testing.T) {
+	t.Run("3.2.2 example", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodGet, "http://example.org/foo", nil)
+		request.Header.Set("Date", "Tue, 07 Jun 2014 20:51:35 GMT")
+		request.Header.Set("X-Example", "Example header\n    with some whitespace.")
+		request.Header.Set("X-EmptyHeader", "")
+		request.Header.Set("Cache-Control", "max-age=60")
+		request.Header.Add("Cache-Control", "must-revalidate")
+		request.Header.Set("Host", "example.org")
+		result, err := httpsig.CreateSignatureInput(
+			params(t, `keyId="test-key-b", created=1402170695, expires=1402170995, `+
+				`headers="(request-target) (created) (expires) host date cache-control x-emptyheader x-example", `+
+				`signature="abc123"`),
+			request,
+		)
+		require.NoError(t, err)
+		expected := strings.Join(
+			[]string{
+				"(request-target): get /foo",
+				"(created): 1402170695",
+				"(expires): 1402170995",
+				"host: example.org",
+				"date: Tue, 07 Jun 2014 20:51:35 GMT",
+				"cache-control: max-age=60, must-revalidate",
+				"x-emptyheader: ",
+				"x-example: Example header\n    with some whitespace.",
+			},
+			"\n",
+		)
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("3.2.2 (created)", func(t *testing.T) {
+		t.Run("error: covered but missing content", func(t *testing.T) {
+			_, err := httpsig.CreateSignatureInput(
+				params(t, `keyId="test-key-b", expires=1402170995, `+
+					`headers="(request-target) (created) (expires) host date cache-control x-emptyheader x-example", `+
+					`signature="abc123"`),
+				nil,
+			)
+			require.Error(t, err)
+		})
+
+		t.Run("error: invalid algorithm", func(t *testing.T) {
+			algorithms := []string{"rsa", "hmac", "ecdsa"}
+			for i := range algorithms {
+				algorithm := fmt.Sprintf(`algorithm="%s"`, algorithms[i])
+				input := algorithm + `, keyId="test-key-b", created=1402170695, expires=1402170995, ` +
+					`headers="(request-target) (created) (expires) host date cache-control x-emptyheader x-example", ` +
+					`signature="abc123"`
+				_, err := httpsig.CreateSignatureInput(params(t, input), nil)
+				require.Error(t, err)
+			}
+		})
+	})
+
+	t.Run("3.2.2 (expires)", func(t *testing.T) {
+		t.Run("error: covered but missing content", func(t *testing.T) {
+			_, err := httpsig.CreateSignatureInput(
+				params(t, `keyId="test-key-b", created=1402170695, `+
+					`headers="(request-target) (created) (expires) host date cache-control x-emptyheader x-example", `+
+					`signature="abc123"`),
+				nil,
+			)
+			require.Error(t, err)
+		})
+
+		t.Run("error: invalid algorithm", func(t *testing.T) {
+			algorithms := []string{"rsa", "hmac", "ecdsa"}
+			for i := range algorithms {
+				algorithm := fmt.Sprintf(`algorithm="%s"`, algorithms[i])
+				input := algorithm + `, keyId="test-key-b", created=1402170695, expires=1402170995, ` +
+					`headers="(request-target) (created) (expires) host date cache-control x-emptyheader x-example", ` +
+					`signature="abc123"`
+				_, err := httpsig.CreateSignatureInput(params(t, input), nil)
+				require.Error(t, err)
+			}
+		})
+
+		t.Run("HTTP Headers", func(t *testing.T) {
+			t.Run("2.1 strips leading and trailing whitespace from HTTP headers", func(t *testing.T) {
+				request := httptest.NewRequest(http.MethodGet, "http://example.org/foo", nil)
+				request.Header.Set("X-EXAMPLE", " \t  test         \n")
+				result, err := httpsig.CreateSignatureInput(
+					params(t, `keyId="test-key-b", signature="0q92uorijlqwelf", headers="x-example"`),
+					request,
+				)
+				require.NoError(t, err)
+				require.Equal(t, "x-example: test", result)
+			})
+
+			t.Run("3.2.2 error: identifier for header field that is not present", func(t *testing.T) {
+				_, err := httpsig.CreateSignatureInput(
+					params(t, `keyId="test-key-b", signature="abc123", headers="x-not-present"`),
+					httptest.NewRequest(http.MethodGet, "http://example.org/foo", nil),
+				)
+				require.Error(t, err)
+			})
+		})
+	})
+}
+
+func params(t *testing.T, val string) *httpsig.SignatureHeaderParams {
+	t.Helper()
+
+	params, err := httpsig.ParseSignatureHeader(val)
+	require.NoError(t, err)
+
+	return params
+}


### PR DESCRIPTION
closes #79 

~~blocked by #87 (`http.Request.Header.Values()` not available in Go 1.13)~~

* parse HTTP `Signature` header
* create signature input from header and http request

Signed-off-by: George Aristy <george.aristy@securekey.com>