### PR TITLE
fix: zcapld middleware returning 200 when validation fails

### DIFF
--- a/pkg/zcapld/middleware.go
+++ b/pkg/zcapld/middleware.go
@@ -140,6 +140,7 @@ func authZHandleFunc(w http.ResponseWriter, r *http.Request,
 	err := hs.Verify(r)
 	if err != nil {
 		maybeConsumeError(config.ErrConsumer, fmt.Errorf("failed to verify http signature: %w", err))
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
 
 		return
 	}
@@ -147,6 +148,7 @@ func authZHandleFunc(w http.ResponseWriter, r *http.Request,
 	zcap, keyID, action, err := parseProofParams(r)
 	if err != nil {
 		maybeConsumeError(config.ErrConsumer, fmt.Errorf("failed to parse proof params: %w", err))
+		http.Error(w, "bad request", http.StatusBadRequest)
 
 		return
 	}
@@ -154,6 +156,7 @@ func authZHandleFunc(w http.ResponseWriter, r *http.Request,
 	verifier, err := NewVerifier(config.CapabilityResolver, config.KeyResolver, config.VerifierOptions...)
 	if err != nil {
 		maybeConsumeError(config.ErrConsumer, fmt.Errorf("middleware failed to init verifier: %w", err))
+		http.Error(w, fmt.Sprintf("failed to init zcap verifier: %s", err.Error()), http.StatusInternalServerError)
 
 		return
 	}
@@ -176,6 +179,7 @@ func authZHandleFunc(w http.ResponseWriter, r *http.Request,
 	)
 	if err != nil {
 		maybeConsumeError(config.ErrConsumer, fmt.Errorf("failed to verify zcap: %w", err))
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
 
 		return
 	}

--- a/pkg/zcapld/middleware_test.go
+++ b/pkg/zcapld/middleware_test.go
@@ -167,6 +167,7 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 		err = hs.Sign(unknownVerificationMethod, thirdPartyRequest)
 		require.NoError(t, err)
 
+		result := httptest.NewRecorder()
 		zcapld.NewHTTPSigAuthHandler(
 			&zcapld.HTTPSigAuthConfig{
 				CapabilityResolver: zcapld.SimpleCapabilityResolver{ownerZCAP.ID: ownerZCAP},
@@ -188,10 +189,11 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 				Action:         "read",
 			},
 			next,
-		).ServeHTTP(httptest.NewRecorder(), thirdPartyRequest)
+		).ServeHTTP(result, thirdPartyRequest)
 		require.Error(t, logErr)
 		require.Contains(t, logErr.Error(), "secret not found")
 		require.False(t, executed)
+		require.Equal(t, http.StatusUnauthorized, result.Code)
 	})
 
 	t.Run("does not authorize HTTP request authn'ed with key different than zcap invoker", func(t *testing.T) {
@@ -253,6 +255,7 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 		err = hs.Sign(unknownVerMethod, thirdPartyRequest)
 		require.NoError(t, err)
 
+		result := httptest.NewRecorder()
 		zcapld.NewHTTPSigAuthHandler(
 			&zcapld.HTTPSigAuthConfig{
 				CapabilityResolver: zcapld.SimpleCapabilityResolver{ownerZCAP.ID: ownerZCAP},
@@ -274,10 +277,11 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 				Action:         "read",
 			},
 			next,
-		).ServeHTTP(httptest.NewRecorder(), thirdPartyRequest)
+		).ServeHTTP(result, thirdPartyRequest)
 		require.Error(t, logErr)
 		require.Contains(t, logErr.Error(), "the authorized invoker does not match the verification method or its controller")
 		require.False(t, executed)
+		require.Equal(t, http.StatusUnauthorized, result.Code)
 	})
 
 	t.Run("does not authorize HTTP request if invoker is not allowed to perform an action", func(t *testing.T) {
@@ -336,6 +340,7 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 		err = hs.Sign(thirdPartyVerMethod, thirdPartyRequest)
 		require.NoError(t, err)
 
+		result := httptest.NewRecorder()
 		zcapld.NewHTTPSigAuthHandler(
 			&zcapld.HTTPSigAuthConfig{
 				CapabilityResolver: zcapld.SimpleCapabilityResolver{ownerZCAP.ID: ownerZCAP},
@@ -357,10 +362,11 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 				Action:         "write",
 			},
 			next,
-		).ServeHTTP(httptest.NewRecorder(), thirdPartyRequest)
+		).ServeHTTP(result, thirdPartyRequest)
 		require.Error(t, logErr)
 		require.Contains(t, logErr.Error(), `capability action "write" is not allowed by the capability`)
 		require.False(t, executed)
+		require.Equal(t, http.StatusUnauthorized, result.Code)
 	})
 
 	t.Run("fails if no signature suites are provided", func(t *testing.T) {
@@ -419,6 +425,7 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 		err = hs.Sign(thirdPartyVerMethod, thirdPartyRequest)
 		require.NoError(t, err)
 
+		result := httptest.NewRecorder()
 		zcapld.NewHTTPSigAuthHandler(
 			&zcapld.HTTPSigAuthConfig{
 				CapabilityResolver: zcapld.SimpleCapabilityResolver{ownerZCAP.ID: ownerZCAP},
@@ -437,10 +444,11 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 				Action:         "read",
 			},
 			next,
-		).ServeHTTP(httptest.NewRecorder(), thirdPartyRequest)
+		).ServeHTTP(result, thirdPartyRequest)
 		require.Error(t, logErr)
 		require.Contains(t, logErr.Error(), "failed to init document verifier: at least one suite must be provided")
 		require.False(t, executed)
+		require.Equal(t, http.StatusInternalServerError, result.Code)
 	})
 
 	t.Run("does not authorize HTTP request if zcap is not provided", func(t *testing.T) {
@@ -486,6 +494,7 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 		err = hs.Sign(thirdPartyVerMethod, thirdPartyRequest)
 		require.NoError(t, err)
 
+		result := httptest.NewRecorder()
 		zcapld.NewHTTPSigAuthHandler(
 			&zcapld.HTTPSigAuthConfig{
 				CapabilityResolver: zcapld.SimpleCapabilityResolver{ownerZCAP.ID: ownerZCAP},
@@ -507,10 +516,11 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 				Action:         "read",
 			},
 			next,
-		).ServeHTTP(httptest.NewRecorder(), thirdPartyRequest)
+		).ServeHTTP(result, thirdPartyRequest)
 		require.Error(t, logErr)
 		require.Contains(t, logErr.Error(), `"capability" was not found in the capability invocation proof`)
 		require.False(t, executed)
+		require.Equal(t, http.StatusUnauthorized, result.Code)
 	})
 
 	t.Run("does not authorize HTTP request if capability-invocation header is not provided", func(t *testing.T) {
@@ -552,6 +562,7 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 		err = hs.Sign(thirdPartyVerMethod, thirdPartyRequest)
 		require.NoError(t, err)
 
+		result := httptest.NewRecorder()
 		zcapld.NewHTTPSigAuthHandler(
 			&zcapld.HTTPSigAuthConfig{
 				CapabilityResolver: zcapld.SimpleCapabilityResolver{ownerZCAP.ID: ownerZCAP},
@@ -573,10 +584,11 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 				Action:         "read",
 			},
 			next,
-		).ServeHTTP(httptest.NewRecorder(), thirdPartyRequest)
+		).ServeHTTP(result, thirdPartyRequest)
 		require.Error(t, logErr)
 		require.Contains(t, logErr.Error(), `"capability-invocation" header is missing`)
 		require.False(t, executed)
+		require.Equal(t, http.StatusBadRequest, result.Code)
 	})
 
 	t.Run("does not authorize HTTP request if HTTP authorization scheme is not 'zcap'", func(t *testing.T) {
@@ -635,6 +647,7 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 		err = hs.Sign(thirdPartyVerMethod, thirdPartyRequest)
 		require.NoError(t, err)
 
+		result := httptest.NewRecorder()
 		zcapld.NewHTTPSigAuthHandler(
 			&zcapld.HTTPSigAuthConfig{
 				CapabilityResolver: zcapld.SimpleCapabilityResolver{ownerZCAP.ID: ownerZCAP},
@@ -656,10 +669,11 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 				Action:         "read",
 			},
 			next,
-		).ServeHTTP(httptest.NewRecorder(), thirdPartyRequest)
+		).ServeHTTP(result, thirdPartyRequest)
 		require.Error(t, logErr)
 		require.Contains(t, logErr.Error(), "invalid invocation scheme")
 		require.False(t, executed)
+		require.Equal(t, http.StatusBadRequest, result.Code)
 	})
 
 	t.Run("does not authorize HTTP request if capability parameter is not a quoted-string", func(t *testing.T) {
@@ -718,6 +732,7 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 		err = hs.Sign(thirdPartyVerMethod, thirdPartyRequest)
 		require.NoError(t, err)
 
+		result := httptest.NewRecorder()
 		zcapld.NewHTTPSigAuthHandler(
 			&zcapld.HTTPSigAuthConfig{
 				CapabilityResolver: zcapld.SimpleCapabilityResolver{ownerZCAP.ID: ownerZCAP},
@@ -739,10 +754,11 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 				Action:         "read",
 			},
 			next,
-		).ServeHTTP(httptest.NewRecorder(), thirdPartyRequest)
+		).ServeHTTP(result, thirdPartyRequest)
 		require.Error(t, logErr)
 		require.Contains(t, logErr.Error(), "'capability' invocation header param value is not a quoted-string")
 		require.False(t, executed)
+		require.Equal(t, http.StatusBadRequest, result.Code)
 	})
 
 	t.Run("does not authorize HTTP request if capability parameter is malformed", func(t *testing.T) {
@@ -788,6 +804,7 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 		err = hs.Sign(thirdPartyVerMethod, thirdPartyRequest)
 		require.NoError(t, err)
 
+		result := httptest.NewRecorder()
 		zcapld.NewHTTPSigAuthHandler(
 			&zcapld.HTTPSigAuthConfig{
 				CapabilityResolver: zcapld.SimpleCapabilityResolver{ownerZCAP.ID: ownerZCAP},
@@ -809,10 +826,11 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 				Action:         "read",
 			},
 			next,
-		).ServeHTTP(httptest.NewRecorder(), thirdPartyRequest)
+		).ServeHTTP(result, thirdPartyRequest)
 		require.Error(t, logErr)
 		require.Contains(t, logErr.Error(), "failed to base64URL-decode value MALFORMED")
 		require.False(t, executed)
+		require.Equal(t, http.StatusBadRequest, result.Code)
 	})
 
 	t.Run("does not authorize HTTP request if action parameter is not a quoted-string", func(t *testing.T) {
@@ -871,6 +889,7 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 		err = hs.Sign(thirdPartyVerMethod, thirdPartyRequest)
 		require.NoError(t, err)
 
+		result := httptest.NewRecorder()
 		zcapld.NewHTTPSigAuthHandler(
 			&zcapld.HTTPSigAuthConfig{
 				CapabilityResolver: zcapld.SimpleCapabilityResolver{ownerZCAP.ID: ownerZCAP},
@@ -892,10 +911,11 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 				Action:         "read",
 			},
 			next,
-		).ServeHTTP(httptest.NewRecorder(), thirdPartyRequest)
+		).ServeHTTP(result, thirdPartyRequest)
 		require.Error(t, logErr)
 		require.Contains(t, logErr.Error(), "'action' invocation header param value is not a quoted-string")
 		require.False(t, executed)
+		require.Equal(t, http.StatusBadRequest, result.Code)
 	})
 
 	t.Run("does not authorize HTTP request if action parameter is missing", func(t *testing.T) {
@@ -954,6 +974,7 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 		err = hs.Sign(thirdPartyVerMethod, thirdPartyRequest)
 		require.NoError(t, err)
 
+		result := httptest.NewRecorder()
 		zcapld.NewHTTPSigAuthHandler(
 			&zcapld.HTTPSigAuthConfig{
 				CapabilityResolver: zcapld.SimpleCapabilityResolver{ownerZCAP.ID: ownerZCAP},
@@ -975,10 +996,11 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 				Action:         "read",
 			},
 			next,
-		).ServeHTTP(httptest.NewRecorder(), thirdPartyRequest)
+		).ServeHTTP(result, thirdPartyRequest)
 		require.Error(t, logErr)
 		require.Contains(t, logErr.Error(), `"action" header is missing`)
 		require.False(t, executed)
+		require.Equal(t, http.StatusBadRequest, result.Code)
 	})
 
 	t.Run("does not authorize HTTP request if an unrecognized capability-invocation parameter is present", func(t *testing.T) { // nolint:lll // excessive indentation otherwise
@@ -1037,6 +1059,7 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 		err = hs.Sign(thirdPartyVerMethod, thirdPartyRequest)
 		require.NoError(t, err)
 
+		result := httptest.NewRecorder()
 		zcapld.NewHTTPSigAuthHandler(
 			&zcapld.HTTPSigAuthConfig{
 				CapabilityResolver: zcapld.SimpleCapabilityResolver{ownerZCAP.ID: ownerZCAP},
@@ -1058,10 +1081,11 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 				Action:         "read",
 			},
 			next,
-		).ServeHTTP(httptest.NewRecorder(), thirdPartyRequest)
+		).ServeHTTP(result, thirdPartyRequest)
 		require.Error(t, logErr)
 		require.Contains(t, logErr.Error(), `unrecognized invocation header param`)
 		require.False(t, executed)
+		require.Equal(t, http.StatusBadRequest, result.Code)
 	})
 
 	t.Run("does not authorize HTTP request if an capability-invocation parameter is not in key=value format", func(t *testing.T) { // nolint:lll // excessive indentation otherwise
@@ -1107,6 +1131,7 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 		err = hs.Sign(thirdPartyVerMethod, thirdPartyRequest)
 		require.NoError(t, err)
 
+		result := httptest.NewRecorder()
 		zcapld.NewHTTPSigAuthHandler(
 			&zcapld.HTTPSigAuthConfig{
 				CapabilityResolver: zcapld.SimpleCapabilityResolver{ownerZCAP.ID: ownerZCAP},
@@ -1128,10 +1153,11 @@ func TestNewHTTPSigAuthorizationHandler(t *testing.T) {
 				Action:         "read",
 			},
 			next,
-		).ServeHTTP(httptest.NewRecorder(), thirdPartyRequest)
+		).ServeHTTP(result, thirdPartyRequest)
 		require.Error(t, logErr)
 		require.Contains(t, logErr.Error(), `invalid key=value format`)
 		require.False(t, executed)
+		require.Equal(t, http.StatusBadRequest, result.Code)
 	})
 
 	t.Run("multi-level delegation", func(t *testing.T) {


### PR DESCRIPTION
The ZCAPLD middleware was returning HTTP status code `200` when validation fails.

Signed-off-by: George Aristy <george.aristy@securekey.com>