### PR TITLE
refactor: replace WithDocumentLoaderCache with ProcessorOpts

### DIFF
--- a/pkg/zcapld/create.go
+++ b/pkg/zcapld/create.go
@@ -34,17 +34,16 @@ func ParseCapability(raw []byte) (*Capability, error) {
 
 // CapabilityOptions configures capabilities.
 type CapabilityOptions struct {
-	ID                  string
-	Parent              string
-	Invoker             string
-	Controller          string
-	Delegator           string
-	AllowedAction       []string
-	InvocationTarget    InvocationTarget
-	Challenge           string
-	Domain              string
-	CapabilityChain     []interface{}
-	DocumentLoaderCache map[string]interface{}
+	ID               string
+	Parent           string
+	Invoker          string
+	Controller       string
+	Delegator        string
+	AllowedAction    []string
+	InvocationTarget InvocationTarget
+	Challenge        string
+	Domain           string
+	CapabilityChain  []interface{}
 }
 
 // CapabilityOption configures CapabilityOptions.
@@ -123,18 +122,12 @@ func WithCapabilityChain(chain ...interface{}) CapabilityOption {
 	}
 }
 
-// WithDocumentLoaderCache sets cached contexts to be used by JSON-LD context document loader.
-func WithDocumentLoaderCache(cache map[string]interface{}) CapabilityOption {
-	return func(o *CapabilityOptions) {
-		o.DocumentLoaderCache = cache
-	}
-}
-
 // Signer signs the Capability.
 type Signer struct {
 	ariessigner.SignatureSuite
 	SuiteType          string
 	VerificationMethod string
+	ProcessorOpts      []jsonld.ProcessorOpts
 }
 
 // NewCapability constructs a new, signed Capability with the options provided.
@@ -197,7 +190,7 @@ func signZCAP(zcap *Capability, signer *Signer, options *CapabilityOptions) erro
 			CapabilityChain:         options.CapabilityChain,
 		},
 		raw,
-		jsonld.WithDocumentLoaderCache(options.DocumentLoaderCache),
+		signer.ProcessorOpts...,
 	)
 	if err != nil {
 		return fmt.Errorf("document signer failed to sign zcap: %w", err)

--- a/pkg/zcapld/create_test.go
+++ b/pkg/zcapld/create_test.go
@@ -72,7 +72,6 @@ func TestNewCapability(t *testing.T) {
 			},
 		}
 		capabilityChain := []interface{}{fmt.Sprintf("urn:zcap:%s", uuid.New().String())}
-		loaderCache := map[string]interface{}{"contextURL": `{"@context":"id": "@id"}`}
 		signer := testSigner(t, kms.ED25519)
 		challenge := uuid.New().String()
 		domain := uuid.New().String()
@@ -82,6 +81,7 @@ func TestNewCapability(t *testing.T) {
 				SignatureSuite:     ed25519signature2018.New(suite.WithSigner(signer)),
 				SuiteType:          ed25519signature2018.SignatureType,
 				VerificationMethod: verificationMethod,
+				ProcessorOpts:      []jsonld.ProcessorOpts{jsonld.WithDocumentLoader(testLDDocumentLoader)},
 			},
 			zcapld.WithID(expected.ID),
 			zcapld.WithParent(expected.Parent),
@@ -93,7 +93,6 @@ func TestNewCapability(t *testing.T) {
 			zcapld.WithChallenge(challenge),
 			zcapld.WithDomain(domain),
 			zcapld.WithCapabilityChain(capabilityChain...),
-			zcapld.WithDocumentLoaderCache(loaderCache),
 		)
 		require.NoError(t, err)
 		require.NotNil(t, result)


### PR DESCRIPTION
This PR removes added in #130 support for `WithDocumentLoaderCache` (it doesn't belong to `CapabilityOptions`) and replaces it with `ProcessorOpts` defined on `Signer`. It should provide a cleaner and more robust API.

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>