### PR TITLE
feat: New command utility to get CSV args

### DIFF
--- a/pkg/utils/cmd/util.go
+++ b/pkg/utils/cmd/util.go
@@ -51,7 +51,12 @@ func GetUserSetVarFromString(cmd *cobra.Command, flagName, envKey string, isOpti
 		" (environment variable) have been set.")
 }
 
-// GetUserSetOptionalVarFromArrayString returns values either command line flag or environment variable.
+// GetUserSetOptionalVarFromArrayString returns the variables set via either command line flag or environment variable.
+// If both are set, then the command line flag takes precedence.
+// For the command line flag, the variables must be set using repeated flags (e.g. --flagName value1 --flagName value2).
+// For the environment variable, the variables are parsed as comma-separated-values (CSV) and returned as a slice.
+// The command line flag must be set as a StringArray.
+// If the variable isn't set, then an empty or nil slice will be returned.
 func GetUserSetOptionalVarFromArrayString(cmd *cobra.Command, flagName, envKey string) []string {
 	//nolint // reason the error will not happen for optional var
 	v, _ := GetUserSetVarFromArrayString(cmd, flagName, envKey, true)
@@ -59,7 +64,12 @@ func GetUserSetOptionalVarFromArrayString(cmd *cobra.Command, flagName, envKey s
 	return v
 }
 
-// GetUserSetVarFromArrayString returns values either command line flag or environment variable.
+// GetUserSetVarFromArrayString returns the variables set via either command line flag or environment variable.
+// If both are set, then the command line flag takes precedence.
+// For the command line flag, the variables must be set using repeated flags (e.g. --flagName value1 --flagName value2).
+// For the environment variable, the variables are parsed as comma-separated-values (CSV) and returned as a slice.
+// The command line flag must be set as a StringArray.
+// If the variable isn't set, then an error will be returned.
 func GetUserSetVarFromArrayString(cmd *cobra.Command, flagName, envKey string, isOptional bool) ([]string, error) {
 	if cmd.Flags().Changed(flagName) {
 		value, err := cmd.Flags().GetStringArray(flagName)
@@ -83,6 +93,55 @@ func GetUserSetVarFromArrayString(cmd *cobra.Command, flagName, envKey string, i
 
 		if value == "" {
 			return []string{}, nil
+		}
+
+		return strings.Split(value, ","), nil
+	}
+
+	return nil, errors.New("Neither " + flagName + " (command line flag) nor " + envKey +
+		" (environment variable) have been set.")
+}
+
+// GetUserSetOptionalCSVVar returns the variables set via either command line flag or environment variable.
+// If both are set, then the command line flag takes precedence.
+// The variables are parsed as comma-separated-values (CSV) and returned as a slice.
+// The command line flag must be set as a StringSlice.
+// If the variable isn't set, then a nil slice will be returned.
+func GetUserSetOptionalCSVVar(cmd *cobra.Command, flagName, envKey string) []string {
+	//nolint // For an optional variable, no error will happen (or we don't care about the error)
+	v, _ := GetUserSetCSVVar(cmd, flagName, envKey, true)
+
+	return v
+}
+
+// GetUserSetCSVVar returns the variables set via either command line flag or environment variable.
+// If both are set, then the command line flag takes precedence.
+// The variables are parsed as comma-separated-values (CSV) and returned as a slice.
+// The command line flag must be set as a StringSlice.
+// If the variable isn't set, then an error will be returned.
+func GetUserSetCSVVar(cmd *cobra.Command, flagName, envKey string, isOptional bool) ([]string, error) {
+	if cmd.Flags().Changed(flagName) {
+		value, err := cmd.Flags().GetStringSlice(flagName)
+		if err != nil {
+			return nil, fmt.Errorf(flagName+" flag not found: %s", err)
+		}
+
+		if len(value) == 0 {
+			return nil, fmt.Errorf("%s value is empty", flagName)
+		}
+
+		return value, nil
+	}
+
+	value, isSet := os.LookupEnv(envKey)
+
+	if isOptional || isSet {
+		if !isOptional && value == "" {
+			return nil, fmt.Errorf("%s value is empty", envKey)
+		}
+
+		if value == "" {
+			return nil, nil
 		}
 
 		return strings.Split(value, ","), nil


### PR DESCRIPTION
Added functions for retrieving user-set variables from either the command line (via the Cobra library) or from an environment variable that are in CSV format.

The new functions are similar to GetUserSetOptionalVarFromArrayString and GetUserSetVarFromArrayString, except that the command line variable can be in CSV format instead of repeated flags. The behaviour of those existing methods can be somewhat unintuitive since they require their input to be in two different formats depending on whether you're using the command line or an environment variable. These new methods provide more consistency, which makes documentation simpler too.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>